### PR TITLE
Github Actions CI/CD pipelines for build, test, and publish

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -2,9 +2,8 @@ name: Build and Test
 
 on:
   push:
-    branches: [ $default-branch ]
   pull_request:
-    branches: [ $default-branch ]
+    branches: [ main ]
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -20,7 +20,11 @@ jobs:
           cache: maven
       - name: Build with Maven
         run: mvn -B package --file pom.xml
-
+      - run: mkdir staging && cp target/*.jar staging
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Package
+          path: staging
       # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
       - name: Update dependency graph
         uses: advanced-security/maven-dependency-submission-action@v3

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -23,4 +23,4 @@ jobs:
 
       # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
       - name: Update dependency graph
-        uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6
+        uses: advanced-security/maven-dependency-submission-action@v3

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -20,7 +20,7 @@ jobs:
           cache: maven
       - name: Build with Maven
         run: mvn -B package --file pom.xml
-      - run: mkdir staging && cp target/*.jar staging
+      - run: mkdir staging && cp carbon-aware-starter/target/*.jar staging
       - uses: actions/upload-artifact@v3
         with:
           name: Package

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,14 +19,14 @@ jobs:
           cache: maven
       - name: Build with Maven
         run: mvn -B package --file pom.xml
+      - name: Publish snapshot package
+        run: cd carbon-aware-starter && mvn --batch-mode deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: mkdir staging && cp carbon-aware-starter/target/*.jar staging
       - uses: actions/upload-artifact@v3
         with:
           name: Package
           path: staging
-      - name: Publish snapshot package
-        run: cd carbon-aware-starter && mvn --batch-mode deploy
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Update dependency graph
         uses: advanced-security/maven-dependency-submission-action@v3

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -24,6 +24,9 @@ jobs:
         with:
           name: Package
           path: staging
-      # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
+      - name: Publish snapshot package
+        run: cd carbon-aware-starter && mvn --batch-mode deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Update dependency graph
         uses: advanced-security/maven-dependency-submission-action@v3

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,7 +1,6 @@
 name: Build and Test
 
 on:
-  push:
   pull_request:
     branches: [ main ]
   # Allows you to run this workflow manually from the Actions tab

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,27 @@
+name: Build and Test
+
+on:
+  push:
+    branches: [ $default-branch ]
+  pull_request:
+    branches: [ $default-branch ]
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: maven
+      - name: Build with Maven
+        run: mvn -B package --file pom.xml
+
+      # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
+      - name: Update dependency graph
+        uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6

--- a/.github/workflows/publish-release-github-packages.yml
+++ b/.github/workflows/publish-release-github-packages.yml
@@ -1,0 +1,20 @@
+name: Publish package to GitHub Packages
+on:
+  release:
+    types: [created]
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+      - name: Publish package
+        run: mvn --batch-mode deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-snapshot-github-packages.yml
+++ b/.github/workflows/publish-snapshot-github-packages.yml
@@ -1,0 +1,19 @@
+name: Publish snapshots to GitHub Packages
+on:
+  push:
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+      - name: Publish package
+        run: mvn --batch-mode deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-snapshot-github-packages.yml
+++ b/.github/workflows/publish-snapshot-github-packages.yml
@@ -14,6 +14,6 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
       - name: Publish package
-        run: mvn --batch-mode deploy
+        run: cd carbon-aware-starter && mvn --batch-mode deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-snapshot-github-packages.yml
+++ b/.github/workflows/publish-snapshot-github-packages.yml
@@ -1,8 +1,12 @@
 name: Publish snapshots to GitHub Packages
 on:
-  push:
+  workflow_run:
+    workflows: ["build-and-test"]
+    types:
+      - completed
 jobs:
   publish:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/carbon-aware-starter/pom.xml
+++ b/carbon-aware-starter/pom.xml
@@ -8,16 +8,19 @@
 		<version>2.7.4</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
+
 	<groupId>com.snowfort</groupId>
 	<artifactId>carbon-aware-starter</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
+
 	<name>carbon-aware-starter</name>
 	<description>Starter for integrating with carbon aware sdk</description>
+
 	<properties>
 		<java.version>17</java.version>
 	</properties>
-	<dependencies>
 
+	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
@@ -50,5 +53,13 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+
+	<distributionManagement>
+		<repository>
+			<id>github</id>
+			<name>GitHub Packages</name>
+			<url>https://maven.pkg.github.com/mtthwcmpbll/spring-boot-carbon-metrics-</url>
+		</repository>
+	</distributionManagement>
 
 </project>

--- a/carbon-aware-starter/pom.xml
+++ b/carbon-aware-starter/pom.xml
@@ -8,13 +8,13 @@
 		<version>2.7.4</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
-	<groupId>com.carbonaware</groupId>
+	<groupId>com.snowfort</groupId>
 	<artifactId>carbon-aware-starter</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
 	<name>carbon-aware-starter</name>
 	<description>Starter for integrating with carbon aware sdk</description>
 	<properties>
-		<java.version>11</java.version>
+		<java.version>17</java.version>
 	</properties>
 	<dependencies>
 

--- a/carbon-aware-starter/pom.xml
+++ b/carbon-aware-starter/pom.xml
@@ -58,7 +58,7 @@
 		<repository>
 			<id>github</id>
 			<name>GitHub Packages</name>
-			<url>https://maven.pkg.github.com/mtthwcmpbll/spring-boot-carbon-metrics-</url>
+			<url>https://maven.pkg.github.com/mtthwcmpbll/spring-boot-carbon-metrics</url>
 		</repository>
 	</distributionManagement>
 

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -4,12 +4,12 @@
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-		<groupId>com.example</groupId>
-		<artifactId>spring-boot-carbonaware-metrics-parent</artifactId>
+		<groupId>com.snowfort</groupId>
+		<artifactId>spring-boot-carbon-metrics-parent</artifactId>
 		<version>0.0.1-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
-	<artifactId>spring-boot-carbonaware-metrics-docs</artifactId>
+	<artifactId>spring-boot-carbon-metrics-docs</artifactId>
 	<packaging>jar</packaging>
 
 	<name>Spring Boot Carbon-Aware Metrics Docs</name>

--- a/examples/multiple-services/hello-service/pom.xml
+++ b/examples/multiple-services/hello-service/pom.xml
@@ -8,7 +8,7 @@
 		<version>2.7.0</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
-	<groupId>com.example</groupId>
+	<groupId>com.snowfort</groupId>
 	<artifactId>hello-service</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
 	<name>hello-service</name>
@@ -43,7 +43,7 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>com.carbonaware</groupId>
+			<groupId>com.snowfort</groupId>
 			<artifactId>carbon-aware-starter</artifactId>
 			<version>0.0.1-SNAPSHOT</version>
 		</dependency>

--- a/examples/multiple-services/weather-service/pom.xml
+++ b/examples/multiple-services/weather-service/pom.xml
@@ -8,7 +8,7 @@
 		<version>2.7.0</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
-	<groupId>com.example</groupId>
+	<groupId>com.snowfort</groupId>
 	<artifactId>weather-service</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
 	<name>weather-service</name>
@@ -51,7 +51,7 @@
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>com.carbonaware</groupId>
+			<groupId>com.snowfort</groupId>
 			<artifactId>carbon-aware-starter</artifactId>
 			<version>0.0.1-SNAPSHOT</version>
 		</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -3,12 +3,12 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<groupId>com.example</groupId>
-	<artifactId>spring-boot-carbonaware-metrics-parent</artifactId>
+	<groupId>com.snowfort</groupId>
+	<artifactId>spring-boot-carbon-metrics-parent</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	
-	<name>spring-boot-carbonaware-metrics-parent</name>
+	<name>spring-boot-carbon-metrics-parent</name>
 	<description>Example API that calls a downstream API and provides a friendly greeting</description>
 
 	<modules>


### PR DESCRIPTION
This includes two new Github Actions workflows:

- build, test, and publish a snapshot to Github Packages
- build a release version on a Github release

This also changes all pom.xml Maven groupId's to `snowfort.com` to be under a verifiable domain name for further release down the road.