### PR TITLE
Spring boot 3 support

### DIFF
--- a/carbon-aware-starter/pom.xml
+++ b/carbon-aware-starter/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.7.4</version>
+		<version>3.0.6</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 

--- a/carbon-aware-starter/src/main/java/com/carbonaware/endpoint/CarbonAwareActuatorEndpoint.java
+++ b/carbon-aware-starter/src/main/java/com/carbonaware/endpoint/CarbonAwareActuatorEndpoint.java
@@ -7,10 +7,14 @@ import com.carbonaware.sci.SoftwareCarbonIntensityService;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.boot.actuate.endpoint.web.annotation.RestControllerEndpoint;
-import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.GetMapping;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 
 @RestControllerEndpoint(id = "carbon")
@@ -29,12 +33,12 @@ public class CarbonAwareActuatorEndpoint {
 
     @GetMapping("/sci")
     public ResponseEntity<SoftwareCarbonIntensity> sciEndpoint() {
-        return new ResponseEntity<>(sciService.getSoftwareCarbonIntensity(), HttpStatus.OK);
+        return new ResponseEntity<>(sciService.getSoftwareCarbonIntensity(), new HttpHeaders(), 200);
     }
 
     @GetMapping("/emissions")
     public ResponseEntity<List<Emissions>> emissions() {
-        return new ResponseEntity<>(client.emissionsForLocation(), HttpStatus.OK);
+        return new ResponseEntity<>(client.emissionsForLocation(), new HttpHeaders(), 200);
     }
 
     private void registerPrometheusEndpoints() {

--- a/carbon-aware-starter/src/main/java/com/carbonaware/models/Emissions.java
+++ b/carbon-aware-starter/src/main/java/com/carbonaware/models/Emissions.java
@@ -1,7 +1,6 @@
 package com.carbonaware.models;
 
 import java.time.ZonedDateTime;
-import java.util.Date;
 
 public class Emissions {
 

--- a/carbon-aware-starter/src/main/java/com/carbonaware/sci/CarbonAwareSdkMarginalEmissionsProvider.java
+++ b/carbon-aware-starter/src/main/java/com/carbonaware/sci/CarbonAwareSdkMarginalEmissionsProvider.java
@@ -4,8 +4,6 @@ import com.carbonaware.apis.CarbonAwareSdkClient;
 import com.carbonaware.models.Emissions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 
 import java.util.Comparator;
 import java.util.List;

--- a/carbon-aware-starter/src/main/java/com/carbonaware/sci/ResourceUtilizationEnergyConsumptionProvider.java
+++ b/carbon-aware-starter/src/main/java/com/carbonaware/sci/ResourceUtilizationEnergyConsumptionProvider.java
@@ -1,11 +1,8 @@
 package com.carbonaware.sci;
 
-import io.micrometer.core.instrument.*;
-import io.micrometer.core.instrument.search.Search;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
 import org.slf4j.Logger;
-
-import java.util.Collection;
-import java.util.Random;
 
 public class ResourceUtilizationEnergyConsumptionProvider implements EnergyConsumptionProvider {
 

--- a/carbon-aware-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/carbon-aware-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.carbonaware.config.CarbonAwareAutoConfiguration

--- a/examples/multiple-services/hello-service/pom.xml
+++ b/examples/multiple-services/hello-service/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.7.0</version>
+		<version>3.0.6</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.snowfort</groupId>

--- a/examples/multiple-services/weather-service/pom.xml
+++ b/examples/multiple-services/weather-service/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.7.0</version>
+		<version>2.7.6</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.snowfort</groupId>


### PR DESCRIPTION
Closes #40 

I've got this working and it's a combination of:

 file for registering auto-configurations, while maintaining backwards compatibility with registration in spring.factories

- The [autoconfiguration file has changed](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Migration-Guide#auto-configuration-files) from `spring.factories` in Spring Boot 2.x to `META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports` in Spring Boot 3.x.  We can support both by keeping both files updated in the library.
- Spring  Boot 3.x changes ResponseEntity where HttpStatus was changed [to a new HttpStatusCode interface](https://github.com/spring-projects/spring-framework/issues/28214). There is not way to support both of these interfaces above, but we can use the ResponseEntity constructor that builds from a raw status int and it will work in both Spring Boot versions.

Unfortunately, this seems like it might be a losing battle based on [this issue](https://github.com/spring-projects/spring-framework/issues/29813), which indicates it's not intended or supported to build a library that supports both. I'm hesitant to drop Spring Boot 2.x support because it'll cut out a lot of existing projects that I'd like to enable SCI measurements for (not just recently created or updated projects). We'll need to figure out a strategy for this in the future, but for now this refactor seems to work.
