### PR TITLE
Add contributing and code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,45 @@
+# Spring Boot Carbon-Aware Metrics Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to make participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic address, without explicit permission
+- Other conduct that could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned with this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at [project team email](). All complaints will be reviewed and investigated, and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), version 2.0, available at https://www.contributor-covenant.org/version/2/0/code_of_conduct.html
+
+For answers to common questions about this code of conduct, see https://www.contributor-covenant.org/faq

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,59 @@
+# How to contribute
+
+We're delighted that you're considering contributing to Spring Boot Carbon-Aware Metrics!
+
+You can contribute in different ways:
+
+* Pick up an issue, express your interest to work on it and get started with it.
+* Increase the test coverage of the library
+* Improve the documentation
+* Report bugs
+* Suggest new features and improvements
+* Spread the word
+
+Code
+--------
+Contributions are made using Github [pull requests](https://help.github.com/en/articles/about-pull-requests):
+
+1. Fork the repository, because imitation is the sincerest form of flattery.
+2. Clone your fork to your local machine.
+3. Create a new branch `feature/xxx` for your changes.
+4. [Create](https://github.com/mtthwcmpbll/spring-boot-carbon-metrics/compare) a new PR with a request to merge to
+   the **main** branch.
+5. Ensure that the description is clear and refers to the issue. Use #issue-id to refer to the issue.
+6. If the contribution requires [updates to documentation](https://mtthwcmpbll.github.io/spring-boot-carbon-metrics/) 
+make sure to update that as well.
+7. Make sure any code contributed is covered by tests and no existing tests are broken.
+
+Coding conventions
+------------------
+We follow the [Java Coding Conventions](https://www.oracle.com/technetwork/java/codeconventions-150003.pdf)
+
+* Minimize mutability
+* Choose self-explanatory names
+* The commit messages should be written in present tense using imperative mood ("Fix" instead of "Fixes", "Improve" 
+instead of "Improved").
+
+Documentation
+-----------------
+There are multiple ways to contribute to [project docs](https://mtthwcmpbll.github.io/spring-boot-carbon-metrics/):
+
+- Read the project documentation and if you find anything that needs to be added/improved, see if you find 
+an [existing issue](https://github.com/mtthwcmpbll/spring-boot-carbon-metrics/issues) or 
+else [create an new issue](https://github.com/mtthwcmpbll/spring-boot-carbon-metrics/issues/new)
+- Submit a pull request with proposed changes.
+
+Issues and Feature Request
+--------------------------
+
+If you encounter a bug or have an idea for a new feature, please submit it to us by 
+[creating an issue](https://github.com/mtthwcmpbll/spring-boot-carbon-metrics/issues/new). Before submitting an issue or 
+feature request, please search the [existing issue](https://github.com/mtthwcmpbll/spring-boot-carbon-metrics/issues) 
+to avoid reporting duplicates.
+
+When submitting an issue or feature request, please provide as much detail as possible, including a clear and concise 
+description of the problem or desired functionality, steps to reproduce the issue, and any relevant code snippets or 
+error messages.
+
+
+


### PR DESCRIPTION
This PR contains a CONTRIBUTING guide(#45) and a CODE_OF_CONDUCT(#47) for opensource contributors.
Also @mtthwcmpbll if you can add some project email id for the Code of Conduct (Line 37)